### PR TITLE
Remove PDM setup action from self-hosted runner action

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -16,10 +16,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up PDM
-        uses: pdm-project/setup-pdm@v3
-        with:
-          python-version: 3.11
       - name: Install dependencies
         run: |
           pdm install -dG test


### PR DESCRIPTION
Assumes that PDM is already installed and configured on the remote machine