### PR TITLE
chore: drops Python 3.8 support

### DIFF
--- a/.github/workflows/test_lint_scan.yml
+++ b/.github/workflows/test_lint_scan.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: [3.9, "3.10", 3.11, 3.12]
 
     runs-on: ${{ matrix.os }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "Next generation GUIDs. Collision-resistant ids optimized for horizontal scaling and performance."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {file = "LICENSE"}
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -18,7 +18,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Topic :: Security :: Cryptography",
     "Typing :: Typed"
 ]
@@ -75,7 +74,7 @@ typing = [
 legacy_tox_ini = """
     [tox]
     min_version = 4
-    env_list = py3{8,9,10,11,12}, check
+    env_list = py3{9,10,11,12}, check
     work_dir = local/.tox
     isolated_build = True
 
@@ -94,7 +93,7 @@ legacy_tox_ini = """
 [tool.ruff]
 line-length = 120
 src = ["src"]
-target-version = "py38"
+target-version = "py39"
 cache-dir = "local/.ruff_cache"
 force-exclude = true
 


### PR DESCRIPTION
## Summary
- Bumps requires-python from >=3.8 to >=3.9 (Python 3.8 EOL since October 2024)
- Updates tox, ruff, and classifiers to match
- Fixes PDM lock file resolution failures where dependencies like safety, platformdirs, and pydantic now require >=3.9