### PR TITLE
chore: removes legacy dependabot.yml (superseded by Renovate)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: daily


### PR DESCRIPTION
## Summary
- Removes `.github/dependabot.yml`, a leftover from this repo's original 2023 import that predates the Renovate migration and was dormant until it fired for the first time today, opening PRs #32-36 that duplicate what Renovate's own PR #31 already bumps
- This repo is now fully managed by the centralized khepri-deps Renovate instance; a second, independent dependency-update source is redundant and creates conflicting PRs
- Duplicate Dependabot PRs (#32-36) will be closed separately